### PR TITLE
Address comments for PR 6

### DIFF
--- a/contracts/Killable.sol
+++ b/contracts/Killable.sol
@@ -1,0 +1,23 @@
+pragma solidity >=0.4.21 <0.6.0;
+
+import "./Ownable.sol";
+
+contract Killable is Ownable {
+  event LogKilled(address indexed account);
+
+  bool private killed;
+
+  modifier whenAlive() {
+    require(!killed, "Can't do that when the contract is killed!");
+    _;
+  }
+
+  function isKilled() public view returns (bool) {
+    return killed;
+  }
+
+  function kill() public onlyOwner whenAlive {
+    killed = true;
+    emit LogKilled(msg.sender);
+  }
+}

--- a/contracts/Killable.sol
+++ b/contracts/Killable.sol
@@ -12,6 +12,11 @@ contract Killable is Ownable {
     _;
   }
 
+  modifier whenKilled() {
+    require(killed, "Can't do that when the contract is alive!");
+    _;
+  }
+
   function isKilled() public view returns (bool) {
     return killed;
   }

--- a/contracts/Ownable.sol
+++ b/contracts/Ownable.sol
@@ -1,6 +1,8 @@
 pragma solidity >=0.4.21 <0.6.0;
 
 contract Ownable {
+  event LogOwnerChanged(address indexed previousOwner, address indexed newOwner);
+
   address private owner;
 
   constructor() public {
@@ -9,6 +11,12 @@ contract Ownable {
 
   function getOwner() public view returns (address) {
     return owner;
+  }
+
+  function changeOwner(address newOwner) public onlyOwner {
+    require(newOwner != address(0), "New owner can't be zero address!");
+    emit LogOwnerChanged(owner, newOwner);
+    owner = newOwner;
   }
 
   modifier onlyOwner() {

--- a/contracts/Pausable.sol
+++ b/contracts/Pausable.sol
@@ -27,8 +27,8 @@ contract Pausable is Ownable {
     emit LogPaused(msg.sender);
   }
 
-  function unpause() public onlyOwner {
-    require(paused, "Can't unpause a non-paused contract!");
+  function resume() public onlyOwner {
+    require(paused, "Can't resume a non-paused contract!");
     paused = false;
     emit LogUnpaused(msg.sender);
   }

--- a/contracts/Pausable.sol
+++ b/contracts/Pausable.sol
@@ -21,8 +21,7 @@ contract Pausable is Ownable {
     return paused;
   }
 
-  function pause() public onlyOwner {
-    require(!paused, "Can't pause a paused contract!");
+  function pause() public onlyOwner whenRunning {
     paused = true;
     emit LogPaused(msg.sender);
   }

--- a/contracts/Pausable.sol
+++ b/contracts/Pausable.sol
@@ -8,8 +8,8 @@ contract Pausable is Ownable {
 
   bool private paused;
 
-  constructor() public {
-    paused = false;
+  constructor(bool _paused) public {
+    paused = _paused;
   }
 
   modifier whenNotPaused() {

--- a/contracts/Pausable.sol
+++ b/contracts/Pausable.sol
@@ -12,7 +12,7 @@ contract Pausable is Ownable {
     paused = _paused;
   }
 
-  modifier whenNotPaused() {
+  modifier whenRunning() {
     require(!paused, "Can't do that when the contract is paused!");
     _;
   }

--- a/contracts/Splitter.sol
+++ b/contracts/Splitter.sol
@@ -14,7 +14,7 @@ contract Splitter is Pausable {
   constructor() Pausable(false) public {
   }
 
-  function split(address _beneficiary1, address _beneficiary2) external payable whenNotPaused {
+  function split(address _beneficiary1, address _beneficiary2) external payable whenRunning {
     require(_beneficiary1 != address(0) && _beneficiary2 != address(0), "Beneficiary's address must not be zero!");
     require(msg.value > 0, "Must split more than zero ether!");
     require(msg.value.mod(2) == 0, "The ether to be splitted must be even!");
@@ -25,7 +25,7 @@ contract Splitter is Pausable {
     emit LogSplitted(msg.sender, msg.value, _beneficiary1, _beneficiary2);
   }
 
-  function withdraw() external whenNotPaused {
+  function withdraw() external whenRunning {
     uint256 balanceToWithdraw = balances[msg.sender];
     require(balanceToWithdraw > 0, "Balance must be grater than zero to withdraw!");
     balances[msg.sender] = 0;

--- a/contracts/Splitter.sol
+++ b/contracts/Splitter.sol
@@ -2,8 +2,9 @@ pragma solidity >=0.4.21 <0.6.0;
 
 import "./SafeMath.sol";
 import "./Pausable.sol";
+import "./Killable.sol";
 
-contract Splitter is Pausable {
+contract Splitter is Pausable, Killable {
   using SafeMath for uint256;
 
   event LogSplitted(address indexed sender, uint256 amount, address indexed beneficiary1, address indexed beneficiary2);
@@ -14,7 +15,7 @@ contract Splitter is Pausable {
   constructor() Pausable(false) public {
   }
 
-  function split(address _beneficiary1, address _beneficiary2) external payable whenRunning {
+  function split(address _beneficiary1, address _beneficiary2) external payable whenRunning whenAlive {
     require(_beneficiary1 != address(0) && _beneficiary2 != address(0), "Beneficiary's address must not be zero!");
     require(msg.value > 0, "Must split more than zero ether!");
     require(msg.value.mod(2) == 0, "The ether to be splitted must be even!");
@@ -25,7 +26,7 @@ contract Splitter is Pausable {
     emit LogSplitted(msg.sender, msg.value, _beneficiary1, _beneficiary2);
   }
 
-  function withdraw() external whenRunning {
+  function withdraw() external whenRunning whenAlive {
     uint256 balanceToWithdraw = balances[msg.sender];
     require(balanceToWithdraw > 0, "Balance must be grater than zero to withdraw!");
     balances[msg.sender] = 0;

--- a/contracts/Splitter.sol
+++ b/contracts/Splitter.sol
@@ -11,6 +11,9 @@ contract Splitter is Pausable {
 
   mapping (address => uint256) public balances;
 
+  constructor() Pausable(false) public {
+  }
+
   function split(address _beneficiary1, address _beneficiary2) external payable whenNotPaused {
     require(_beneficiary1 != address(0) && _beneficiary2 != address(0), "Beneficiary's address must not be zero!");
     require(msg.value > 0, "Must split more than zero ether!");

--- a/contracts/Splitter.sol
+++ b/contracts/Splitter.sol
@@ -18,8 +18,10 @@ contract Splitter is Pausable, Killable {
   function split(address _beneficiary1, address _beneficiary2) external payable whenRunning whenAlive {
     require(_beneficiary1 != address(0) && _beneficiary2 != address(0), "Beneficiary's address must not be zero!");
     require(msg.value > 0, "Must split more than zero ether!");
-    require(msg.value.mod(2) == 0, "The ether to be splitted must be even!");
 
+    if (msg.value.mod(2) == 1) {
+      balances[msg.sender] = balances[msg.sender].add(1);
+    }
     uint256 half = msg.value.div(2);
     balances[_beneficiary1] = balances[_beneficiary1].add(half);
     balances[_beneficiary2] = balances[_beneficiary2].add(half);

--- a/contracts/Splitter.sol
+++ b/contracts/Splitter.sol
@@ -33,4 +33,12 @@ contract Splitter is Pausable, Killable {
     emit LogWithdrawn(msg.sender, balanceToWithdraw);
     msg.sender.transfer(balanceToWithdraw);
   }
+
+  function withdrawAll() external onlyOwner whenKilled {
+    uint256 balanceToWithdraw = address(this).balance;
+    require(balanceToWithdraw > 0, "Balance must be grater than zero to withdraw!");
+    balances[msg.sender] = 0;
+    emit LogWithdrawn(msg.sender, balanceToWithdraw);
+    msg.sender.transfer(balanceToWithdraw);
+  }
 }

--- a/test/splitter.js
+++ b/test/splitter.js
@@ -18,6 +18,25 @@ contract('Splitter', accounts => {
     assert.strictEqual((await contract.methods.getOwner().call()), owner);
   });
 
+  context('When change the owner)', () => {
+    let tx;
+    beforeEach(async () => {
+      // Arrange & Act
+      tx = await contract.methods.changeOwner(bob).send({from: owner});
+    });
+
+    it('should change the owner to Bob', async () => {
+      assert.strictEqual((await contract.methods.getOwner().call()), bob);
+    });
+
+    it('should emit the LogOwnerChanged event', async () => {
+      // Assert
+      assert.strictEqual(tx.events.LogOwnerChanged.event, 'LogOwnerChanged');
+      assert.strictEqual(tx.events.LogOwnerChanged.returnValues.previousOwner, owner);
+      assert.strictEqual(tx.events.LogOwnerChanged.returnValues.newOwner, bob);
+    });
+  });
+
   context('When owner splits 0.02 ether (the number is even)', () => {
     let tx;
     beforeEach(async () => {

--- a/test/splitter.js
+++ b/test/splitter.js
@@ -180,7 +180,7 @@ contract('Splitter', accounts => {
     });
   });
 
-  context('When owner pause the contract', () => {
+  context('When owner pauses the contract', () => {
     context('if the contract is not paused', () => {
       let tx;
       beforeEach(async () => {
@@ -217,7 +217,7 @@ contract('Splitter', accounts => {
     });
   });
 
-  context('When owner unpause the contract', () => {
+  context('When owner resumes the contract', () => {
     context('if the contract is paused', () => {
       let tx;
       beforeEach(async () => {
@@ -225,7 +225,7 @@ contract('Splitter', accounts => {
         await contract.methods.pause().send({from: owner});
 
         // Act
-        tx = await contract.methods.unpause().send({from: owner});
+        tx = await contract.methods.resume().send({from: owner});
       });
   
       it('the contract should not be paused', async () => {
@@ -244,14 +244,14 @@ contract('Splitter', accounts => {
       it('should fail', async () => {
         // Act & Assert
         await truffleAssert.reverts(
-          contract.methods.unpause().send({from: owner}),
-          'revert Can\'t unpause a non-paused contract!'
+          contract.methods.resume().send({from: owner}),
+          'revert Can\'t resume a non-paused contract!'
         );
       });
     });
   });
 
-  context('When not owner pause the contract', () => {
+  context('When not owner pauses the contract', () => {
     it('should fail', async () => {
       // Act & Assert
       await truffleAssert.reverts(
@@ -261,11 +261,11 @@ contract('Splitter', accounts => {
     });
   });
 
-  context('When not owner unpause the contract', () => {
+  context('When not owner resumes the contract', () => {
     it('should fail', async () => {
       // Act & Assert
       await truffleAssert.reverts(
-        contract.methods.unpause().send({from: someoneElse}),
+        contract.methods.resume().send({from: someoneElse}),
         'Only owner can do this!'
       );
     });

--- a/test/splitter.js
+++ b/test/splitter.js
@@ -211,7 +211,7 @@ contract('Splitter', accounts => {
         // Act & Assert
         await truffleAssert.reverts(
           contract.methods.pause().send({from: owner}),
-          'revert Can\'t pause a paused contract!'
+          'revert Can\'t do that when the contract is paused!'
         );
       });
     });


### PR DESCRIPTION
In this PR, I addressed the comments for PR #6 

@adelRestom I have addressed all your comments except for the App.js.

>App.js
>
> 1. Very important thing we usually do is to protect the user from losing Ether on function calls that would fail; we do that by first calling the function with .call() which runs it locally/simulation (locally => no transaction => no mining => no gas consumed => no Ether lost), if that call doesn't fail then we proceed to actually call the function (i.e. call it without .call.
> 2. You used on('transactionHash'), also use on('receipt') to inspect the receipt status (that it's == 1) and to inform the user of a successful transaction

For the first comment, do you call all the `send` method like
`await contract.methods.split(beneficiary1Address, beneficiary2Address).call();`
before
```
await contract.methods.split(beneficiary1Address, beneficiary2Address).send({
  from: accounts[0],
  value: web3.utils.toWei(etherToSplit, 'ether')
});
```

For the second comment, I have checked the `receipt` in the promise call - see `tx` variable, please.

```
  const tx = await contract.methods.split(beneficiary1Address, beneficiary2Address).send({
        from: accounts[0],
        value: web3.utils.toWei(etherToSplit, 'ether')
      }).on('transactionHash', txHash => {
        this.setState({ splitMessage: `Transaction ${txHash} submitted, waiting for the network to mine` });
      }).on('receipt', receipt => {
        console.log(receipt);
      });
      console.log(tx);
```

I print out `receipt` and `tx`, they are exactly same.

@xavierlepretre can you please have a look as well? thanks
